### PR TITLE
fix(autoware_mapless_planning_msgs): change data type of segment ids …

### DIFF
--- a/autoware_mapless_planning_msgs/msg/Segment.msg
+++ b/autoware_mapless_planning_msgs/msg/Segment.msg
@@ -1,4 +1,4 @@
 uint16 id
 Linestring[2] linestrings # Two linestings define the geometry of a segment.
-int16[] successor_segment_id # All the ids of the successor segments.
-int16[] neighboring_segment_id # All the ids of the neighbor segments.
+int32[] successor_segment_id # All the ids of the successor segments.
+int32[] neighboring_segment_id # All the ids of the neighbor segments.

--- a/mapless_architecture/autoware_local_mission_planner/test/test_mission_planner.cpp
+++ b/mapless_architecture/autoware_local_mission_planner/test/test_mission_planner.cpp
@@ -196,10 +196,10 @@ autoware_mapless_planning_msgs::msg::RoadSegments GetTestRoadModelForRecenterTes
   message.segments[1].linestrings[1].poses[1].position.y = 2.0;
   message.segments[1].linestrings[1].poses[1].position.z = 0.0;
 
-  int16_t neigh_1 = 1;
-  std::vector<int16_t> neighboring_ids = {neigh_1};
+  int32_t neigh_1 = 1;
+  std::vector<int32_t> neighboring_ids = {neigh_1};
   message.segments[0].neighboring_segment_id = neighboring_ids;
-  std::vector<int16_t> neighboring_ids_2 = {};
+  std::vector<int32_t> neighboring_ids_2 = {};
   message.segments[1].neighboring_segment_id = neighboring_ids_2;
 
   return message;


### PR DESCRIPTION
…from int16 to int32

## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Bug Fix

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description

<!-- Describe what this PR changes. -->

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
